### PR TITLE
Make mtom xop stream interface more flexible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bratislava/ginis-sdk",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bratislava/ginis-sdk",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bratislava/ginis-sdk",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A small wrapper for most commonly used requests towards the Bratislava GINIS system",
   "main": "dist/index.js",
   "files": [

--- a/src/api/ssl/Pridat-soubor.ts
+++ b/src/api/ssl/Pridat-soubor.ts
@@ -1,4 +1,4 @@
-import { ReadStream } from 'fs'
+import { Readable } from 'stream'
 import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
 
@@ -40,7 +40,7 @@ const pridatSouborRequestProperties = [
 export type SslPridatSouborRequest = {
   [K in (typeof pridatSouborRequestProperties)[number] as K]?: string
 } & {
-  Obsah?: ReadStream
+  Obsah?: Readable
 }
 
 const pridatSouborSchema = z.object({
@@ -91,7 +91,11 @@ export async function pridatSouborMtom(
   bodyObj: SslPridatSouborRequest
 ): Promise<SslPridatSouborResponse> {
   if (!bodyObj.Obsah) {
-    bodyObj.Obsah = new ReadStream()
+    bodyObj.Obsah = new Readable({
+      read() {
+        this.push(null)
+      },
+    })
   }
 
   const url = this.config.urls.ssl_mtom

--- a/src/utils/request-util.ts
+++ b/src/utils/request-util.ts
@@ -1,6 +1,5 @@
 /* eslint-disable sonarjs/slow-regex */
-import { ReadStream } from 'fs'
-import { PassThrough } from 'stream'
+import { PassThrough, Readable } from 'stream'
 import { parseStringPromise as parseXml } from 'xml2js'
 import { ZodType } from 'zod'
 
@@ -100,7 +99,7 @@ export function createMultipartRequestConfig(
 export function createMultipartRequestBody(
   config: GinisConfig,
   requestInfo: XmlRequestInfo,
-  fileStream: ReadStream,
+  fileStream: Readable,
   boundary: string,
   requestContentId: string,
   fileContentId: string


### PR DESCRIPTION
This was intended to be used with Minio S3 which provides `Readable`. Additional capabilities of `ReadStream` are not utilized anyway, so lessening library stream requirements is in order.